### PR TITLE
Update example.js to include changes to finalName

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ npm install @idrsolutions/buildvu
 ```javascript
 var buildvu = require('@idrsolutions/buildvu');
 
-var endpoint = "http://localhost:8080/microservice-example/";
+var endpoint = "http://localhost:8080/buildvu-microservice/";
 
 buildvu.convert({
     endpoint: endpoint,
@@ -47,7 +47,7 @@ buildvu.convert({
 ```javascript
 var buildvu = require('@idrsolutions/buildvu');
 
-var endpoint = "http://localhost:8080/microservice-example/";
+var endpoint = "http://localhost:8080/buildvu-microservice/";
 
 buildvu.convert({
     endpoint: endpoint,

--- a/example.js
+++ b/example.js
@@ -31,7 +31,7 @@ function successListener(e) {
    console.log("Converted " + e.downloadUrl);
 }
 
-var endpoint = "http://localhost:8080/microservice-example/";
+var endpoint = "http://localhost:8080/buildvu-microservice/";
 
 buildvu.convert({
     endpoint: endpoint,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@idrsolutions/buildvu",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@idrsolutions/buildvu",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "BuildVu Node.js Client is the Node.js API for IDRSolutions' BuildVu Microservice Example.",
   "main": "buildvu-client.js",
   "repository": {


### PR DESCRIPTION
Changed endpoint to buildvu-microservice, this is due to the changes to the finalName in the pom.xml in buildvu-microservice-example